### PR TITLE
Specify pro/turbo invite urls via config.py

### DIFF
--- a/xenon/bot.py
+++ b/xenon/bot.py
@@ -1,5 +1,6 @@
 from aiohttp import ClientSession
 from discord.ext import commands as cmd
+import discord
 from motor.motor_asyncio import AsyncIOMotorClient
 import aioredis
 import json
@@ -164,6 +165,17 @@ class Xenon(cmd.AutoShardedBot):
         ):
             log.info("Shard ID %s has acquired the IDENTIFY lock." % shard_id)
             return await super().launch_shard(gateway, shard_id)
+
+    @property
+    def invite(self):
+        invite = self.config.invite_url
+        if not invite:
+            invite = discord.utils.oauth_url(
+                client_id=self.user.id,
+                permissions=discord.Permissions(8)
+            )
+
+        return invite
 
     @property
     def config(self):

--- a/xenon/cogs/basics.py
+++ b/xenon/cogs/basics.py
@@ -69,8 +69,8 @@ class Basics(cmd.Cog, name="\u200BOthers"):
         """Invite Xenon"""
         await ctx.send(**ctx.em("**Invite Xenon**\n\n"
                                 f"[Xenon]({ctx.bot.invite})\n"
-                                "[Xenon Pro](https://discordapp.com/api/oauth2/authorize?client_id=524652984425250847&permissions=8&scope=bot) Use `x!pro` to get more information.\n"
-                                "[Xenon Turbo](https://discordapp.com/api/oauth2/authorize?client_id=598534174894194719&permissions=8&scope=bot)",
+                                f"[Xenon Pro]({self.bot.config.pro_url}) Use `x!pro` to get more information.\n"
+                                f"[Xenon Turbo]({self.bot.config.turbo_url})",
                                 type="info"))
 
     @cmd.command(aliases=["i", "stats", "status", "about"])

--- a/xenon/cogs/basics.py
+++ b/xenon/cogs/basics.py
@@ -68,7 +68,7 @@ class Basics(cmd.Cog, name="\u200BOthers"):
     async def invite(self, ctx):
         """Invite Xenon"""
         await ctx.send(**ctx.em("**Invite Xenon**\n\n"
-                                "[Xenon]("+helpers.get_selfinvite(self.bot.user.id, self.bot.config.forced_inviteurl)+")\n"
+                                f"[Xenon]({ctx.bot.invite})\n"
                                 "[Xenon Pro](https://discordapp.com/api/oauth2/authorize?client_id=524652984425250847&permissions=8&scope=bot) Use `x!pro` to get more information.\n"
                                 "[Xenon Turbo](https://discordapp.com/api/oauth2/authorize?client_id=598534174894194719&permissions=8&scope=bot)",
                                 type="info"))
@@ -81,7 +81,7 @@ class Basics(cmd.Cog, name="\u200BOthers"):
         embed.description = "Server Backups, Templates and more"
         embed.title = "Xenon"
         embed.set_thumbnail(url=self.bot.user.avatar_url)
-        embed.add_field(name="Invite", value="[Click Here]("+helpers.get_selfinvite(self.bot.user.id, self.bot.config.forced_inviteurl)+")")
+        embed.add_field(name="Invite", value=f"[Click Here]({ctx.bot.invite})")
         embed.add_field(name="Discord", value="[Click Here](https://discord.club/discord)")
         embed.add_field(name="Prefix", value=ctx.config.prefix)
         embed.add_field(name="Guilds", value=helpers.format_number(await self.bot.get_guild_count()))

--- a/xenon/cogs/basics.py
+++ b/xenon/cogs/basics.py
@@ -68,7 +68,7 @@ class Basics(cmd.Cog, name="\u200BOthers"):
     async def invite(self, ctx):
         """Invite Xenon"""
         await ctx.send(**ctx.em("**Invite Xenon**\n\n"
-                                "[Xenon](https://discord.club/invite/xenon)\n"
+                                "[Xenon]("+helpers.get_selfinvite(self.bot.user.id, self.bot.config.forced_inviteurl)+")\n"
                                 "[Xenon Pro](https://discordapp.com/api/oauth2/authorize?client_id=524652984425250847&permissions=8&scope=bot) Use `x!pro` to get more information.\n"
                                 "[Xenon Turbo](https://discordapp.com/api/oauth2/authorize?client_id=598534174894194719&permissions=8&scope=bot)",
                                 type="info"))
@@ -81,7 +81,7 @@ class Basics(cmd.Cog, name="\u200BOthers"):
         embed.description = "Server Backups, Templates and more"
         embed.title = "Xenon"
         embed.set_thumbnail(url=self.bot.user.avatar_url)
-        embed.add_field(name="Invite", value="[Click Here](https://discord.club/invite/xenon)")
+        embed.add_field(name="Invite", value="[Click Here]("+helpers.get_selfinvite(self.bot.user.id, self.bot.config.forced_inviteurl)+")")
         embed.add_field(name="Discord", value="[Click Here](https://discord.club/discord)")
         embed.add_field(name="Prefix", value=ctx.config.prefix)
         embed.add_field(name="Guilds", value=helpers.format_number(await self.bot.get_guild_count()))

--- a/xenon/config.py
+++ b/xenon/config.py
@@ -27,6 +27,8 @@ class Config:
     support_guild = 410488579140354049
     owner_id = 386861188891279362
     invite_url = None  # Set to None to generate one automatically
+    pro_url = "https://discordapp.com/api/oauth2/authorize?client_id=524652984425250847&permissions=8&scope=bot"
+    turbo_url = "https://discordapp.com/api/oauth2/authorize?client_id=598534174894194719&permissions=8&scope=bot"
 
     identifier = "xenon"
 

--- a/xenon/config.py
+++ b/xenon/config.py
@@ -20,7 +20,7 @@ class Config:
     shards_per_pod = 1
     pod_id = _pod_id
 
-    prefix = "x!"
+    prefix = "x;"
 
     dbl_token = None
 

--- a/xenon/config.py
+++ b/xenon/config.py
@@ -26,6 +26,7 @@ class Config:
 
     support_guild = 410488579140354049
     owner_id = 386861188891279362
+    forced_inviteurl = "https://discord.club/invite/xenon" # Set to False to autogenerate the invite link
 
     identifier = "xenon"
 

--- a/xenon/config.py
+++ b/xenon/config.py
@@ -26,7 +26,7 @@ class Config:
 
     support_guild = 410488579140354049
     owner_id = 386861188891279362
-    forced_inviteurl = "https://discord.club/invite/xenon" # Set to False to autogenerate the invite link
+    invite_url = None  # Set to None to generate one automatically
 
     identifier = "xenon"
 

--- a/xenon/config.py
+++ b/xenon/config.py
@@ -20,7 +20,7 @@ class Config:
     shards_per_pod = 1
     pod_id = _pod_id
 
-    prefix = "x;"
+    prefix = "x!"
 
     dbl_token = None
 

--- a/xenon/utils/helpers.py
+++ b/xenon/utils/helpers.py
@@ -28,12 +28,6 @@ def format_number(number):
 
     return "{:,}{}".format(number, suffix)
 
-def get_selfinvite(clientid, forcedinviteurl):
-    if forcedinviteurl == False:
-        return "https://discordapp.com/oauth2/authorize?client_id="+str(clientid)+"&scope=bot&permissions=8"
-    else:
-        return forcedinviteurl
-
 
 async def ask_question(ctx, question, converter=str):
     question_msg = await ctx.send(**ctx.em(question, type="wait_for"))

--- a/xenon/utils/helpers.py
+++ b/xenon/utils/helpers.py
@@ -28,6 +28,12 @@ def format_number(number):
 
     return "{:,}{}".format(number, suffix)
 
+def get_selfinvite(clientid, forcedinviteurl):
+    if forcedinviteurl == False:
+        return "https://discordapp.com/oauth2/authorize?client_id="+str(clientid)+"&scope=bot&permissions=8"
+    else:
+        return forcedinviteurl
+
 
 async def ask_question(ctx, question, converter=str):
     question_msg = await ctx.send(**ctx.em(question, type="wait_for"))


### PR DESCRIPTION
Added settings pro_url and turbo_url to specify the invite URLs of the pro/turbo bot
Also synces dev to master. (That was not intended, but I guess it's okay)