### PR TITLE
Fix channel ID translator not working sometimes

### DIFF
--- a/xenon/utils/backups.py
+++ b/xenon/utils/backups.py
@@ -315,10 +315,13 @@ class BackupLoader:
                     category=discord.Object(self.id_translator.get(tchannel["category"])),
                     reason=self.reason
                 )
-                await created.edit(
-                    topic=self._translate_mentions(tchannel["topic"]),
-                    nsfw=tchannel["nsfw"],
-                )
+                try:
+                    await created.edit(
+                        topic=self._translate_mentions(tchannel["topic"]),
+                        nsfw=tchannel["nsfw"],
+                    )
+                except Exception:
+                    pass
 
                 self.id_translator[tchannel["id"]] = created.id
             except Exception:

--- a/xenon/utils/backups.py
+++ b/xenon/utils/backups.py
@@ -182,6 +182,9 @@ class BackupLoader:
         return overwrites
 
     def _translate_mentions(self, text):
+        if not text:
+            return text
+
         formats = ["<#%s>", "<@&%s>"]
         for key, value in self.id_translator.items():
             for _format in formats:
@@ -315,15 +318,12 @@ class BackupLoader:
                     category=discord.Object(self.id_translator.get(tchannel["category"])),
                     reason=self.reason
                 )
-                try:
-                    await created.edit(
-                        topic=self._translate_mentions(tchannel["topic"]),
-                        nsfw=tchannel["nsfw"],
-                    )
-                except Exception:
-                    pass
 
                 self.id_translator[tchannel["id"]] = created.id
+                await created.edit(
+                    topic=self._translate_mentions(tchannel["topic"]),
+                    nsfw=tchannel["nsfw"],
+                )
             except Exception:
                 pass
 


### PR DESCRIPTION
No, @Merlintor, it was actually your fault in code that broke my own modifications, because in some cases it stopped at the lines that I have "tried out" now.
"My code is working" LMAO
But okay, I am not angry at you ;-)
Actually I learned a lot about debugging xenon when I found this out!
Also, the actual problem occurs when there is some untranslatable mention in channels topic. Exact error was: 404 Not Found :thinking::upside_down_face:
